### PR TITLE
Allow Symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
     "doctrine/annotations": "^1.0",
     "doctrine/orm": "^2.4.5",
     "doctrine/doctrine-bundle": "^1.6",
-    "phpdocumentor/reflection-docblock": "^3.0",
-    "symfony/asset": "^3.0",
-    "symfony/expression-language": "^3.0",
-    "symfony/security-bundle": "^3.0",
-    "symfony/twig-bundle": "^3.0",
-    "symfony/validator": "^3.0"
+    "phpdocumentor/reflection-docblock": "^3.0 || ^4.0",
+    "symfony/asset": "^3.0 || ^4.0",
+    "symfony/expression-language": "^3.0 || ^4.0",
+    "symfony/security-bundle": "^3.0 || ^4.0",
+    "symfony/twig-bundle": "^3.0 || ^4.0",
+    "symfony/validator": "^3.0 || ^4.0"
   }
 }


### PR DESCRIPTION
Symfony 4 Beta is out now. In order to be able to use Symfony 4 with API-Pack, it's required to allow Symfony v4 and also ReflectionDocBlock v4.

This is especially important because Symfony recommends API-Pack as best practice for creating APIs  with Symfony (please look at the docs for Symfony Flex and at the Symfony Recipes Server). It would be a pity if API-Pack cannot be used with the current Beta of Symfony 4.

Thanks.