### PR TITLE
Add annotation dependency for Symfony Flex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "symfony/expression-language": "^3.0 || ^4.0",
     "symfony/security-bundle": "^3.0 || ^4.0",
     "symfony/twig-bundle": "^3.0 || ^4.0",
-    "symfony/validator": "^3.0 || ^4.0"
+    "symfony/validator": "^3.0 || ^4.0",
+    "sensio/framework-extra-bundle": "^5.0"
   }
 }


### PR DESCRIPTION
Hi guys,

I was installing the api-pack via Symfony Flex and couldn't complete without installing `annot` recipe (https://github.com/sensiolabs/SensioFrameworkExtraBundle) first.

Adding the dependency to `composer.json` should fix it.

Please have a look at the steps to reproduce the issue:

```
//macOs High Sierra
PHP 7.1.7 (cli) (built: Jul 15 2017 18:08:09) ( NTS )
Copyright (c) 1997-2017 The PHP Group
Zend Engine v3.1.0, Copyright (c) 1998-2017 Zend Technologies
```
1. create project:
```
$ composer create-project symfony/skeleton api_flex/
Installing symfony/skeleton (v3.3.5)
...
Executing script assets:install --symlink --relative public [OK]

              
 What's next? 
              

  * Run your application:
    1. Change to the project directory
    2. Execute the php -S 127.0.0.1:8000 -t public command;
    3. Browse to the http://localhost:8000/ URL.

       Quit the server with CTRL-C.
       Run composer require symfony/web-server-bundle for a better web server.

  * Read the documentation at https://symfony.com/doc
```
2. require api
```
$ cd api_flex/
$ composer req api
...
Writing lock file
Generating autoload files
Symfony operations: 7 recipes (8bb573343e5ff2a4f82ffebebc67937b)
  - Configuring symfony/translation (3.3): From github.com/symfony/recipes:master
  - Configuring symfony/twig-bundle (3.3): From github.com/symfony/recipes:master
  - Configuring symfony/security-bundle (3.3): From github.com/symfony/recipes:master
  - Configuring doctrine/annotations (1.0): From github.com/symfony/recipes:master
  - Configuring doctrine/doctrine-cache-bundle (1.3.2): From auto-generated recipe
  - Configuring doctrine/doctrine-bundle (1.6): From github.com/symfony/recipes:master
  - Configuring api-platform/core (2.1): From github.com/symfony/recipes:master

Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!  
!!   // Clearing the cache for the dev environment with debug                       
!!   // true                                                                        
!!  
!!  
!!                                                                                 
!!    [Symfony\Component\Config\Exception\FileLoaderLoadException]                 
!!    Cannot load resource "../src/Controller/". Make sure annotations are enable  
!!    d.                                                                           
!!                                                                                 
!!  
!!  cache:clear [--no-warmup] [--no-optional-warmers] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-e|--env ENV] [--no-debug] [--] <command>
!!  
!!  

Installation failed, reverting ./composer.json to its original content.
```
After requiring the https://github.com/sensiolabs/SensioFrameworkExtraBundle, it works fine:
```
$ composer req annot
Using version ^5.0 for sensio/framework-extra-bundle
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
  - Installing sensio/framework-extra-bundle (v5.0.1)
    Loading from cache

sensio/framework-extra-bundle suggests installing symfony/psr-http-message-bridge (To use the PSR-7 converters)
Writing lock file
Generating autoload files
Symfony operations: 1 recipe (7c94609e828c9c5c31bafacf48d92609)
  - Configuring sensio/framework-extra-bundle (4.0): From github.com/symfony/recipes:master
Executing script cache:clear [OK]
Executing script assets:install --symlink --relative public [OK]
```
And then, requiring api again:
```
$ composer req api
Using version ^1.0 for api-platform/api-pack
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Nothing to install or update
Writing lock file
Generating autoload files
Executing script cache:clear [OK]
Executing script assets:install --symlink --relative public [OK]
```