### PR TITLE
Add README.md.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2017 Kévin Dunglas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Enqueue Job Queue Pack for Symfony Flex
+# A Pack for API Platform
 
 This is a Flex pack to install API Platform, a next-generation web framework designed to easily create API-first projects without compromising extensibility and flexibility.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Enqueue Job Queue Pack for Symfony Flex
+
+This is a Flex pack to install API Platform, a next-generation web framework designed to easily create API-first projects without compromising extensibility and flexibility.
+
+See the [API Platform's](https://github.com/api-platform/api-platform) github page.
+
+## License
+
+The MIT License (MIT). Please see [License File](LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a Flex pack to install API Platform, a next-generation web framework designed to easily create API-first projects without compromising extensibility and flexibility.
 
-See the [API Platform's](https://github.com/api-platform/api-platform) github page.
+See the [API Platform](https://github.com/api-platform/api-platform) github page.
 
 ## License
 


### PR DESCRIPTION
Shamelessly "borrowed" `README.md` from:

* https://github.com/php-enqueue/job-queue-flex-pack/blob/master/README.md

Added LICENSE file from:

* https://github.com/api-platform/api-platform/blob/master/LICENSE

It is possible that:

* The year on the LICENCE is wrong (or I've given the code to the WRONG copyright holder)
* The README contents are completely wrong

As for the last point, I am trying to guess what this package does and `api-platform/core` is the most likely primary reason for installing this pack.

Closes #1