### PR TITLE
Add NelmioCors by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,14 +9,12 @@
     "doctrine/annotations": "^1.0",
     "doctrine/orm": "^2.4.5",
     "doctrine/doctrine-bundle": "^1.6",
+    "nelmio/cors-bundle": "^1.5",
     "phpdocumentor/reflection-docblock": "^3.0 || ^4.0",
     "symfony/asset": "^3.0 || ^4.0",
     "symfony/expression-language": "^3.0 || ^4.0",
     "symfony/security-bundle": "^3.0 || ^4.0",
     "symfony/twig-bundle": "^3.0 || ^4.0",
     "symfony/validator": "^3.0 || ^4.0"
-  },
-  "suggest": {
-    "nelmio/cors-bundle": "To support CORS."
   }
 }


### PR DESCRIPTION
Many people struggle to properly configure CORS handling when creating an API with Symfony 4. To solve this problem, this PR adds NelmioCors (that now has [a dedicated Flex recipe](https://github.com/symfony/recipes/pull/308)) to the pack.

Thanks to the new [Flex's unpack feature](http://fabien.potencier.org/symfony4-unpack-the-packs.html), adding an extra dependency in the pack isn't a big deal anymore, because the user can easily remove it if he wants to customize the installation.

Another advantage of this PR: it will reduce the gap between the standard [API Platform distribution](https://github.com/api-platform/api-platform/) and `composer req api`.