### PR TITLE
fix (composer.json): Update dependency for symfony/webssite-skeleton ^5.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "doctrine/orm": "^2.4.5",
     "doctrine/doctrine-bundle": "^1.6 || ^2.0",
     "nelmio/cors-bundle": "^1.5 || ^2.0",
-    "phpdocumentor/reflection-docblock": "^3.0 || ^4.0",
+    "phpdocumentor/reflection-docblock": "^3.0 || ^4.0 || ^5.0",
     "symfony/asset": "*",
     "symfony/expression-language": "*",
     "symfony/security-bundle": "*",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | might ?
| Deprecations? | no
| Tickets       | #26
| License       | MIT
| Doc PR        | none

allow installation with symfony/website-skeleton version 5 and above